### PR TITLE
ci: test with asan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
           git clone https://github.com/grug-lang/grug-tests
           cd grug-tests
           git checkout main
+          export ASAN=1
           cmake -S . -B build
           cmake --build build
 
@@ -81,6 +82,7 @@ jobs:
 
       - name: Run grug-tests tests (Python ${{ matrix.python-version }})
         run: |
+          export LD_PRELOAD=$(gcc -print-file-name=libasan.so)
           coverage run -m pytest --grug-tests-path=./grug-tests -s -v
 
       - name: Run grug-bench tests (Python ${{ matrix.python-version }})

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ coverage html
 
 Run `python -m http.server` in a different terminal to view the HTML output in your browser.
 
+If you compiled grug-tests with `ASAN=1` in your environment, you need to pass `export LD_PRELOAD=$(gcc -print-file-name=libasan.so)` before you run pytest.
+
 Pass `--whitelisted-test=f32_too_big` to only run the test called `f32_too_big`.
 
 Alternatively, you can *walk* through the tests and set breakpoints by installing the [Python Debugger](https://marketplace.visualstudio.com/items?itemName=ms-python.debugpy) VS Code extension. Hit `F5` to run all tests. You can edit `.vscode/launch.json` to pass `--whitelisted-test=f32_too_big`.


### PR DESCRIPTION
This PR adds ASAN, since the issue [Fix CI failing on Python 3.7.17](https://github.com/grug-lang/grug-for-python/issues/37) found that there is currently UB in grug-tests.