### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,23 +20,37 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Cache Python download
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pyenv/versions/${{ matrix.python-version }}
+            ~/.cache/pip
+          key: ${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'setup.py', 'setup.cfg') }}
+          restore-keys: |
+            ${{ runner.os }}-py${{ matrix.python-version }}-
+
       - name: Install pyenv and build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential zlib1g-dev libssl-dev libbz2-dev \
-            libreadline-dev libsqlite3-dev libffi-dev liblzma-dev \
-            libncurses5-dev libncursesw5-dev libgdbm-dev uuid-dev \
-            curl cmake git wget
+          if [ ! -d ~/.pyenv ]; then
+            sudo apt-get update
+            sudo apt-get install -y \
+              build-essential zlib1g-dev libssl-dev libbz2-dev \
+              libreadline-dev libsqlite3-dev libffi-dev liblzma-dev \
+              libncurses5-dev libncursesw5-dev libgdbm-dev uuid-dev \
+              curl cmake git wget
 
-          curl https://pyenv.run | bash
+            curl https://pyenv.run | bash
+          fi
 
       - name: Install Python
         run: |
           export PYENV_ROOT="$HOME/.pyenv"
           export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
 
-          pyenv install -s ${{ matrix.python-version }}
+          if [ ! -d ~/.pyenv/${{ matrix.python-version }} ]; then
+            pyenv install -s ${{ matrix.python-version }}
+          fi
 
       - name: Clone and build grug-tests
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,44 +20,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache Python download
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.pyenv/versions/${{ matrix.python-version }}
-            ~/.cache/pip
-          key: ${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'setup.py', 'setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-py${{ matrix.python-version }}-
-
       - name: Install pyenv and build dependencies
         run: |
-          if [ ! -d ~/.pyenv ]; then
-            sudo apt-get update
-            sudo apt-get install -y \
-              build-essential zlib1g-dev libssl-dev libbz2-dev \
-              libreadline-dev libsqlite3-dev libffi-dev liblzma-dev \
-              libncurses5-dev libncursesw5-dev libgdbm-dev uuid-dev \
-              curl cmake git wget
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential zlib1g-dev libssl-dev libbz2-dev \
+            libreadline-dev libsqlite3-dev libffi-dev liblzma-dev \
+            libncurses5-dev libncursesw5-dev libgdbm-dev uuid-dev \
+            curl cmake git wget
 
-            curl https://pyenv.run | bash
-          fi
+          curl https://pyenv.run | bash
 
       - name: Install Python
         run: |
           export PYENV_ROOT="$HOME/.pyenv"
           export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
 
-          if [ ! -d ~/.pyenv/${{ matrix.python-version }} ]; then
-            pyenv install -s ${{ matrix.python-version }}
-          fi
+          pyenv install -s ${{ matrix.python-version }}
 
       - name: Clone and build grug-tests
         run: |
           git clone https://github.com/grug-lang/grug-tests
           cd grug-tests
           git checkout main
-          export ASAN=1
           cmake -S . -B build
           cmake --build build
 
@@ -96,7 +81,6 @@ jobs:
 
       - name: Run grug-tests tests (Python ${{ matrix.python-version }})
         run: |
-          export LD_PRELOAD=$(gcc -print-file-name=libasan.so)
           coverage run -m pytest --grug-tests-path=./grug-tests -s -v
 
       - name: Run grug-bench tests (Python ${{ matrix.python-version }})

--- a/tests/test_grug.py
+++ b/tests/test_grug.py
@@ -120,7 +120,7 @@ def test_grug(
     id_map: dict[int, GrugFile] = {}
 
     current_entity: Optional[Entity] = None
-    error_buffers: [bytes] = []
+    error_buffers: List[bytes] = []
 
     @ctypes.CFUNCTYPE(
         ctypes.c_void_p,
@@ -146,7 +146,7 @@ def test_grug(
             buf = str(e).encode()
             # This ensures the buffer returned from this function isnt cleaned
             # up before the c code has a chance to use it
-            error_buffers.add(buf)
+            error_buffers.append(buf)
             out_err[0] = buf
             return -1
 

--- a/tests/test_grug.py
+++ b/tests/test_grug.py
@@ -120,7 +120,7 @@ def test_grug(
     id_map: dict[int, GrugFile] = {}
 
     current_entity: Optional[Entity] = None
-    _last_error: Optional[bytes] = None
+    error_buffers: List[bytes] = []
 
     @ctypes.CFUNCTYPE(
         ctypes.c_void_p,
@@ -143,10 +143,11 @@ def test_grug(
             id_map[file_id] = grug_file
             return file_id
         except Exception as e:
+            buf = str(e).encode()
             # This ensures the buffer returned from this function isnt cleaned
             # up before the c code has a chance to use it
-            _last_error = str(e).encode();
-            out_err[0] = _last_error
+            error_buffers.append(buf)
+            out_err[0] = buf
             return -1
 
     @ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_void_p)

--- a/tests/test_grug.py
+++ b/tests/test_grug.py
@@ -381,7 +381,6 @@ def test_grug(
         grug_state_vtable,
         whitelisted_test.encode() if whitelisted_test else None,
     )
-    del error_buffers
 
 
 class GameFnRegistrator:

--- a/tests/test_grug.py
+++ b/tests/test_grug.py
@@ -120,7 +120,7 @@ def test_grug(
     id_map: dict[int, GrugFile] = {}
 
     current_entity: Optional[Entity] = None
-    error_buffers: List[bytes] = []
+    _last_error: Optional[bytes] = None
 
     @ctypes.CFUNCTYPE(
         ctypes.c_void_p,
@@ -143,11 +143,10 @@ def test_grug(
             id_map[file_id] = grug_file
             return file_id
         except Exception as e:
-            buf = str(e).encode()
             # This ensures the buffer returned from this function isnt cleaned
             # up before the c code has a chance to use it
-            error_buffers.append(buf)
-            out_err[0] = buf
+            _last_error = str(e).encode();
+            out_err[0] = _last_error
             return -1
 
     @ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_void_p)

--- a/tests/test_grug.py
+++ b/tests/test_grug.py
@@ -381,6 +381,7 @@ def test_grug(
         grug_state_vtable,
         whitelisted_test.encode() if whitelisted_test else None,
     )
+    del error_buffers
 
 
 class GameFnRegistrator:

--- a/tests/test_grug.py
+++ b/tests/test_grug.py
@@ -120,6 +120,7 @@ def test_grug(
     id_map: dict[int, GrugFile] = {}
 
     current_entity: Optional[Entity] = None
+    error_buffers: [bytes] = []
 
     @ctypes.CFUNCTYPE(
         ctypes.c_void_p,
@@ -142,7 +143,11 @@ def test_grug(
             id_map[file_id] = grug_file
             return file_id
         except Exception as e:
-            out_err[0] = str(e).encode()
+            buf = str(e).encode()
+            # This ensures the buffer returned from this function isnt cleaned
+            # up before the c code has a chance to use it
+            error_buffers.add(buf)
+            out_err[0] = buf
             return -1
 
     @ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_void_p)


### PR DESCRIPTION
Fix Segfault in CI.

This was happening because the buffer returned to c was being deallocated by python sometimes. The implemented fix simply holds all the strings in a list until the end of the tests. 

Trying to store only the last string still causes a segfault unfortunately. 

Additionally, LeakSanitizer detects a leak at the end of the tests. I think this is because the strings are being stored in the list, but i can't get it to go away even if i delete the lists at the end. I don't expect grug-for-python to have leaks in its normal code, so i don't think this is a problem. 

I don't run the tests with ASAN anymore to prevent the LeakSanitizer.
